### PR TITLE
Fix a logic bug in the month report

### DIFF
--- a/month.html.tmpl
+++ b/month.html.tmpl
@@ -448,7 +448,7 @@
                 </td>
                 <td class="stats_data">
                   $year.rainRate.max
-                  #if $year.rainRate.max > 0
+                  #if $year.rainRate.max.raw > 0
                   $gettext("at") $year.rainRate.maxtime
                   #end if
                 </td>


### PR DESCRIPTION
One of the maxima was not converted to a raw value, so we were comparing an int to a AggTypeBinder.

Introduced in commit 6196c92

Fixes #38